### PR TITLE
add print wrappers to gp calls in roots.m

### DIFF
--- a/endomorphisms/magma/roots.m
+++ b/endomorphisms/magma/roots.m
@@ -29,7 +29,7 @@ assert BaseRing(f) eq Rationals();
 assert BaseRing(K) eq Rationals();
 g := DefiningPolynomial(K);
 cmd := Sprintf(
-"{f = Pol(Vecrev(%o),'x); g = Pol(Vecrev(%o),'y); K = nfinit(g); apply(h->apply(c->vector(poldegree(g),i,polcoeff(c,i-1)),lift(Vecrev(h))),nffactor(K,f)[,1]~)",
+"{f = Pol(Vecrev(%o),'x); g = Pol(Vecrev(%o),'y); K = nfinit(g); print1(apply(h->apply(c->vector(poldegree(g),i,polcoeff(c,i-1)),lift(Vecrev(h))),nffactor(K,f)[,1]~))",
 Coefficients(f), Coefficients(g));
 s := Pipe("gp -q -D timer=0", cmd);
 
@@ -47,7 +47,7 @@ intrinsic SplittingFieldPari(f::RngUPolElt) -> .
 //return SplittingField(f);
 assert BaseRing(f) eq Rationals();
 cmd := Sprintf(
-"{f = Pol(Vecrev(%o),'x); nfsplitting(f)",
+"{f = Pol(Vecrev(%o),'x); print1(nfsplitting(f))",
 Coefficients(f), Coefficients(f));
 s := Pipe("gp -q -D timer=0", cmd);
 R<x> := PolynomialRing(BaseRing(f));


### PR DESCRIPTION
If you have readline installed gp output will be color coded by default, which screws up the parsing of the result.  Explicit printing fixes this problem.