### PR TITLE
Poldred

### DIFF
--- a/endomorphisms/magma/heuristic/Relative.m
+++ b/endomorphisms/magma/heuristic/Relative.m
@@ -291,7 +291,7 @@ if K eq L then
 end if;
 
 /* Polishing */
-K0, hKK0 := Polredabs(K);
+K0, hKK0 := Polred(K);
 hKK0i := Inverse(hKK0);
 hK0L := hom< K0 -> L | hKL(hKK0i(K0.1)) >;
 DescendAttributesExtra(L, K0, hK0L);
@@ -301,9 +301,9 @@ end intrinsic;
 
 
 intrinsic ImproveFieldExtra(K::Fld) -> Fld, Map
-{Polredabs plus attribute transfer. Returns the isomorphism.}
+{Polred plus attribute transfer. Returns the isomorphism.}
 
-K0, hKK0 := Polredabs(K);
+K0, hKK0 := Polred(K);
 TransferAttributesExtra(K, K0, hKK0);
 return K0, hKK0;
 
@@ -406,7 +406,7 @@ F := K`base; genFCC0 := EmbedExtra(F.1);
 CC := K`CC; genKCC0 := EmbedExtra(K.1);
 
 /* Get absolute field and we need an iso that respects results so far */
-Lrel := NumberField(gK); Labs := AbsoluteField(Lrel); L, h := Polredabs(Labs);
+Lrel := NumberField(gK); Labs := AbsoluteField(Lrel); L, h := Polred(Labs);
 anew := h(Labs ! Lrel.1); f := MinimalPolynomial(K.1); rtsf := RootsPari(f, L);
 L`CC := CC; L`base := F;
 
@@ -608,7 +608,7 @@ genKCC0 := EmbedExtra(K.1);
 
 /* Get absolute field and we need an iso that respects results so far */
 Lrel := Compositum(K, SplittingFieldPari(gQQ)); Labs := AbsoluteField(Lrel);
-L, h := Polredabs(Labs); L`CC := CC; L`base := F;
+L, h := Polred(Labs); L`CC := CC; L`base := F;
 rtsg := RootsPari(gQQ, L); f := MinimalPolynomial(K.1); rtsf := RootsPari(f, L);
 
 /* Choose compatible root */
@@ -687,7 +687,7 @@ genFCC0 := EmbedExtra(F.1); genKCC0 := EmbedExtra(K.1);
  * A more general Pari/GP version should be used */
 L, rtsg := SplittingField(gK);
 if IsQQ(K) then h1 := hom< K -> L | >; else h1 := hom< K -> L | L ! (K.1) >; end if;
-L, h2 := Polredabs(L); h := h1*h2;
+L, h2 := Polred(L); h := h1*h2;
 L`CC := CC; L`base := F; L`base_gen := h(K`base_gen); anew := h2(rtsg[1]);
 
 /* Choose compatible embedding */

--- a/endomorphisms/magma/heuristic/Structure.m
+++ b/endomorphisms/magma/heuristic/Structure.m
@@ -140,7 +140,7 @@ EndoDescQQ := [ ];
 for i in [1..#Ds] do
     D := Ds[i]; idem := idems[i];
     E1 := AlgebraOverCenter(D); F := BaseField(E1);
-    FDesc := FieldDescriptionExtra(Polredabs(F)); dimF := #FDesc - 1;
+    FDesc := FieldDescriptionExtra(Polred(F)); dimF := #FDesc - 1;
 
     /* Some relative dimensions */
     mdimfac := Rank(MatrixFromIdempotent(C, GensC, idem, EndoRep)) div 2;

--- a/endomorphisms/magma/polredabs.m
+++ b/endomorphisms/magma/polredabs.m
@@ -1,7 +1,11 @@
-intrinsic Polredabs(f::RngUPolElt : Best := false) -> RngUPolElt, SeqEnum, BoolElt
-  { A smallest generating polynomial of the number field, using pari. }
+intrinsic Polred(f::RngUPolElt : Best:="dynamic") -> RngUPolElt, SeqEnum, BoolElt
+  { A smallest generating polynomial of the number field, using polredabs/polredbest in pari. }
 
-  vprint EndoFind, 3 : "Starting polredabs...";
+  if Best cmpeq "dynamic" then
+    Best := Degree(f) gt 8;
+  end if;
+
+  vprint EndoFind, 3 : "Starting Polred...";
   if Best then
     cmdp := "polredbest";
   else
@@ -29,16 +33,28 @@ intrinsic Polredabs(f::RngUPolElt : Best := false) -> RngUPolElt, SeqEnum, BoolE
     f0 /:= LeadingCoefficient(f0);
     return f0, [0,1] cat [0: i in [1..Degree(f)-2]], false;
   end try;
-  vprint EndoFind, 3 : "done.";
+  vprint EndoFind, 3 : "Polred done.";
   return Parent(f) ! sspol, ssroot, true;
+end intrinsic
+
+intrinsic Polredabs(f::RngUPolElt) -> RngUPolElt, SeqEnum, BoolElt
+  { A smallest generating polynomial of the number field, using polredabs in pari. }
+  return Polred(f : Best:=false);
 end intrinsic;
+
+
+intrinsic Polredbest(f::RngUPolElt) -> RngUPolElt, SeqEnum, BoolElt
+  { A smallest generating polynomial of the number field, using polredbest in pari. }
+  return Polred(f : Best:=true);
+end intrinsic;
+
 
 intrinsic Polredbestabs(f::RngUPolElt) -> RngUPolElt, SeqEnum, BoolElt
   {A smallest generating polynomial of the number field, using pari.  First polredbest, then polredabs.}
 
   K := (Degree(f) ne 1) select NumberField(f) else RationalsAsNumberField();
-  fbest, fbest_root := Polredabs(f : Best := true);
-  fredabs, fredabs_root, bl := Polredabs(fbest : Best := false);
+  fbest, fbest_root := Polredbest(f);
+  fredabs, fredabs_root, bl := Polredabs(fbest);
   Kbest := (Degree(fbest) ne 1) select NumberField(fbest) else RationalsAsNumberField();
   iotabest := hom<K -> Kbest | fbest_root>;
   Kredabs := (Degree(fredabs) ne 1) select NumberField(fredabs) else RationalsAsNumberField();
@@ -47,13 +63,13 @@ intrinsic Polredbestabs(f::RngUPolElt) -> RngUPolElt, SeqEnum, BoolElt
   return fredabs, Eltseq(iota(K.1)), bl;
 end intrinsic;
 
-intrinsic Polredabs(K::Fld : Best := false) -> FldNum, Map, BoolElt
-  { A smallest generating polynomial of the number field, using pari. }
+intrinsic Polred(K::Fld : Best:="dynamic") -> FldNum, Map, BoolElt
+  { A smallest generating polynomial of the number field, using polredabs/polredbest pari. }
 
   if Type(K) eq FldRat then
     return K, hom< K -> K | >;
   else
-    fredabs, fredabs_root, bl := Polredabs(DefiningPolynomial(K));
+    fredabs, fredabs_root, bl := Polredabs(DefiningPolynomial(K) : Best:=Best);
     if IsZero(fredabs) then
         return K, hom<K -> K | K.1>, false;
     end if;
@@ -63,6 +79,17 @@ intrinsic Polredabs(K::Fld : Best := false) -> FldNum, Map, BoolElt
   end if;
 end intrinsic;
 
+intrinsic Polredbest(K::Fld) -> FldNum, Map, BoolElt
+  { A smallest generating polynomial of the number field, using polredabs in pari. }
+  return Polred(K : Best:=false);
+end intrinsic;
+
+
+intrinsic Polredbest(K::Fld) -> FldNum, Map, BoolElt
+  { A smallest generating polynomial of the number field, using polredbest in pari. }
+  return Polred(K : Best:=true);
+end intrinsic;
+
 intrinsic Polredbestabs(K::Fld) -> RngUPolElt, Map, BoolElt
   {A smallest generating polynomial of the number field, using pari.  First polredbest, then polredabs.}
 
@@ -70,7 +97,7 @@ intrinsic Polredbestabs(K::Fld) -> RngUPolElt, Map, BoolElt
     return K, hom< K -> K | >;
   else
     f := DefiningPolynomial(K);
-    fbest, fbest_root, bl0 := Polredabs(f : Best := true);
+    fbest, fbest_root, bl0 := Polredbest(f);
     if IsZero(fbest) then
         return K, hom<K -> K | K.1>, false;
     end if;

--- a/endomorphisms/magma/polredabs.m
+++ b/endomorphisms/magma/polredabs.m
@@ -1,6 +1,7 @@
 intrinsic Polred(f::RngUPolElt : Best:="dynamic") -> RngUPolElt, SeqEnum, BoolElt
   { A smallest generating polynomial of the number field, using polredabs/polredbest in pari. }
 
+  require &or[ Best cmpeq elt : elt in [* "dynamic", false, true *]]: "Best must be in [\"dynamic\", false, true]";
   if Best cmpeq "dynamic" then
     Best := Degree(f) gt 8;
   end if;


### PR DESCRIPTION
The old `Polredabs` became `Polred` where picks polredbest/polredabs base on the degree being smaller or larger than 8.
And created the versions `Polredabs` and `Polrebest` where it calls what the name says.

Also replaced all the old calls of `Polredabs` with `Polred`.

and left this call to `Polredbestabs` intact https://github.com/edgarcosta/endomorphisms/blob/master/endomorphisms/magma/roots.m#L77
