### PR TITLE
Only compare significant bits

### DIFF
--- a/endomorphisms/magma/heuristic/CCExtra.m
+++ b/endomorphisms/magma/heuristic/CCExtra.m
@@ -78,8 +78,8 @@ RR`height_bound := RR ! height_bound;
 end intrinsic;
 
 
-intrinsic AlmostEqual(rcc::FldComElt, r::.) -> BoolElt
-{ return if rcc is an approximation of r }
-    require assigned Parent(rcc)`epscomp: "the first argument must have as a parent a ComplexFieldExtra";
-    return Abs(rcc - EmbedExtra(r))/(r eq 0 select 1 else Abs(r)) lt Parent(rcc)`epscomp;
+intrinsic AlmostEqual(approx::FldComElt, alg::.) -> BoolElt
+{ return if approx is an approximation of r }
+    require assigned Parent(approx)`epscomp: "the first argument must have as a parent a ComplexFieldExtra";
+    return Abs(approx - EmbedExtra(alg))/(alg eq 0 select 1 else Abs(alg)) lt Parent(approx)`epscomp;
 end intrinsic;

--- a/endomorphisms/magma/heuristic/CCExtra.m
+++ b/endomorphisms/magma/heuristic/CCExtra.m
@@ -78,8 +78,8 @@ RR`height_bound := RR ! height_bound;
 end intrinsic;
 
 
-intrinsic AlmostEqual(approx::FldComElt, alg::.) -> BoolElt
+intrinsic AlmostEqual(approx::., alg::.) -> BoolElt
 { return if approx is an approximation of r }
-    require assigned Parent(approx)`epscomp: "the first argument must have as a parent a ComplexFieldExtra";
+    require assigned Parent(approx)`epscomp: "the first argument must have as a parent a RealFieldExtra or ComplexFieldExtra";
     return Abs(approx - EmbedExtra(alg))/(alg eq 0 select 1 else Abs(alg)) lt Parent(approx)`epscomp;
 end intrinsic;

--- a/endomorphisms/magma/heuristic/CCExtra.m
+++ b/endomorphisms/magma/heuristic/CCExtra.m
@@ -76,3 +76,10 @@ CC`height_bound := RR ! height_bound;
 RR`height_bound := RR ! height_bound;
 
 end intrinsic;
+
+
+intrinsic AlmostEqual(rcc::FldComElt, r::.) -> BoolElt
+{ return if rcc is an approximation of r }
+    require assigned Parent(rcc)`epscomp: "the first argument must have as a parent a ComplexFieldExtra";
+    return Abs(rcc - EmbedExtra(r))/(r eq 0 select 1 else Abs(r)) lt Parent(rcc)`epscomp;
+end intrinsic;

--- a/endomorphisms/magma/heuristic/Recognition.m
+++ b/endomorphisms/magma/heuristic/Recognition.m
@@ -246,7 +246,8 @@ return Matrix(rows_alg), test;
 end intrinsic;
 
 
-function RationalReconstruction(r);
+intrinsic RationalReconstruction(r::FldComElt) ->  BoolElt, FldRatElt
+{ Returns an approximation of the complex number r as an element of QQ }
     CC := Parent(r); r1 := Real(r); r2 := Imaginary(r); p := Precision(r2);
     if r2 ne Parent(r2) ! 0 then e := Log(AbsoluteValue(r2)); else e := -p; end if;
     if -e lt p/2 then return false, 0; end if;
@@ -257,7 +258,7 @@ function RationalReconstruction(r);
     if b ne best then return false, 0; end if;
     test := Abs(r - b) lt Parent(r)`epscomp;
     return test, b;
-end function;
+end intrinsic;
 
 
 intrinsic AlgebraizeElementExtra(aCC::FldComElt, K::Fld : UseRatRec := true, UseQQ := false, UpperBound := 16, DegreeDivides := Infinity()) -> .
@@ -269,7 +270,6 @@ if not UseQQ then return AlgebraizeElementLLL(aCC, K); end if;
 CCK := K`CC; CCiota := Parent(K`iota);
 assert Precision(Parent(aCC)) ge Precision(CCK);
 minpol := MinimalPolynomialLLL(aCC, RationalsExtra(Precision(CCK)) : UpperBound := UpperBound, DegreeDivides := DegreeDivides);
-
 vprint EndoFind, 3 : "";
 vprint EndoFind, 3 : "Finding roots in field with Pari...";
 rts := RootsPari(minpol, K);

--- a/endomorphisms/magma/heuristic/Recognition.m
+++ b/endomorphisms/magma/heuristic/Recognition.m
@@ -177,7 +177,7 @@ row := Rows(Ker)[1]; den := row[#Eltseq(row)];
 /* There is no height test in this case: Be aware of the corresponding risk */
 if den ne 0 then
     a := &+[ row[i + 1]*genK^i : i in [0..(degK - 1)] ] / den;
-    if Abs(EmbedExtra(a) - aCC) le CCK`epscomp then
+    if AlmostEqual(aCC, a) then
         vprint EndoFind, 3 : a;
         vprint EndoFind, 3 : "done algebraizing element.";
         return true, a;
@@ -199,7 +199,7 @@ Ker, test_ker := IntegralLeftKernel(M : CalcAlg := true);
 if not test_ker then return Rationals() ! 0, false; end if;
 
 q := Ker[1,1] / Ker[1,2];
-if (RR ! Abs(q - aCC)) le RR`epscomp then
+if AlmostEqual(aCC, q) then
     return q, true;
 else
     return Rationals() ! 0, false;
@@ -218,7 +218,7 @@ K, test_ker := IntegralLeftKernel(M : CalcAlg := true);
 if not test_ker then return Rationals() ! 0, false; end if;
 
 q := K[1,1] / K[1,2];
-if (RR ! Abs(q - aRR)) le RR`epscomp then
+if AlmostEqual(aRR, q) then
     return q, true;
 else
     return Rationals() ! 0, false;
@@ -256,8 +256,7 @@ intrinsic RationalReconstruction(r::FldComElt) ->  BoolElt, FldRatElt
         i +:= 5; best := b; b := BestApproximation(r1, 10^i);
     end while;
     if b ne best then return false, 0; end if;
-    test := Abs(r - b) lt Parent(r)`epscomp;
-    return test, b;
+    return AlmostEqual(r, b), b;
 end intrinsic;
 
 
@@ -276,7 +275,7 @@ rts := RootsPari(minpol, K);
 vprint EndoFind, 3 : rts;
 vprint EndoFind, 3 : "done finding roots in field with Pari.";
 
-for rt in rts do if Abs(EmbedExtra(rt) - aCC) le CCK`epscomp then return true, rt; end if; end for;
+for rt in rts do if AlmostEqual(aCC, rt) then return true, rt; end if; end for;
 return false, 0;
 
 end intrinsic;


### PR DESCRIPTION
This resolves #52, as it boils down to
```
> CC<I> := ComplexFieldExtra(210);
> r := -8744296296.29629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629629606p210 + 4.63904903109310867053319761531198167208579141366616950416795464078482675799537244792296275814235137316532497932260242969902884145561411596409311814036853462453181613672980721511881820655940576392237105805190800E-200p210*I;
> test, b := RationalReconstruction(r);
> test, b;
false -236096000000/27
```
as
```
>  ComplexField(10)!Abs(r - b)
2.396878152E-199
```
but the right way to compare if two nonzero floating points are close to each other is not by absolute difference, but by their relative differences
```
> ComplexField(10)!Abs(r - b)/Abs(b)
2.741076092E-209
```
, and voila, with the PR we get
```
> RationalReconstruction(r);
true  -236096000000/27
```

