### PR TITLE
use cached PeriodMatrix only when it makes sense

### DIFF
--- a/endomorphisms/UpperBounds/upper_bounds.py
+++ b/endomorphisms/UpperBounds/upper_bounds.py
@@ -98,7 +98,7 @@ def endomorphisms_upper_bound(frob_list, eta_char0 = None):
             message += " If the upper bound for eta indeed is eta, then the number of factors is a strict upper bound";
             return False, message, eta_char0, t, None, None
         for x, y, hpj in endo:
-            # endo[j] = mpj, mpj*deg(hpj), hpj
+            # endo[j] = m_{p,j}, m_{p,j}*deg(h_{p,j}), h_{p,j}
             frob_factors[(x,y)][i].append( polredabs(hpj) );
 
 

--- a/endomorphisms/magma/heuristic/Periods.m
+++ b/endomorphisms/magma/heuristic/Periods.m
@@ -94,18 +94,24 @@ end while;
 end function;
 
 
-intrinsic PeriodMatrix(X::Crv) -> ModMatFldElt
-{Returns the period matrix of X.}
+intrinsic PeriodMatrix(X::Crv : prec:=false) -> ModMatFldElt
+{Returns the period matrix of X. The optional parameter prec is only used if the curve is not given over RationalsExtra/NumberFieldExtra}
 
 
 F := BaseRing(X);
-require assigned F`iota : "Curve expected to be given with an embedding to the complex numbers, i.e., over RationalsExtra or NumberFieldExtra";
+if not assigned F`iota then
+    // converts a curve to be over a NumberFieldExtra if it is not given in that way
+    X := CurveExtra(X : prec:=prec);
+else
+    require prec cmpeq false: "The optional parameter prec can only used if the curve is not given over RationalsExtra/NumberFieldExtra";
+end if;
+assert assigned F`iota;
 CC := Parent(F`iota);
 vprint EndoFind : "";
 vprint EndoFind : "Calculating period matrix...";
-if assigned X`period_matrix then
+if assigned X`period_matrix and Precision(BaseRing(X`period_matrix)) ge Precision(CC) then
     vprint EndoFind : "using stored period matrix.";
-    return X`period_matrix;
+    return ChangeRing(X`period_matrix, CC);
 end if;
 
 if CurveType(X) eq "genhyp" then


### PR DESCRIPTION
Before:
```
> P<x> := PolynomialRing(Rationals());
> f := 6394*x^6 + 31183*x^5 + 20576*x^4 - 437722*x^3 + 411052*x^2 - 201058*x + 43872;
> X := SimplifiedModel(HyperellipticCurveOfGenus(2,f));
>
> for prec in [30, 100, 1000] do
for>     BaseRing(PeriodMatrix(ChangeRing(X,RationalsExtra(prec))));
for> end for;
Complex field of precision 40
Complex field of precision 40
Complex field of precision 40
```

now

```
> P<x> := PolynomialRing(Rationals());
> f := 6394*x^6 + 31183*x^5 + 20576*x^4 - 437722*x^3 + 411052*x^2 - 201058*x + 43872;
> X := SimplifiedModel(HyperellipticCurveOfGenus(2,f));
>
> for prec in [30, 100, 1000] do
for>     BaseRing(PeriodMatrix(ChangeRing(X,RationalsExtra(prec))));
for> end for;
Complex field of precision 40
Complex field of precision 110
Complex field of precision 1010
```