### PR TITLE
fix: SatoTateGroupG2QQ/SatoTateShorthandG2 read the wrong EndoDesc index

### DIFF
--- a/endomorphisms/magma/heuristic/SatoTate.m
+++ b/endomorphisms/magma/heuristic/SatoTate.m
@@ -13,6 +13,21 @@ import "OverField.m": SubgroupGeneratorsUpToConjugacy;
 forward SatoTateGroupG2QQ;
 forward SatoTateShorthand;
 forward SatoTateShorthandG2;
+forward DescRRShorthand;
+
+function DescRRShorthand(EndoDescRR)
+    descs := [ "RR", "CC", "undef", "HH" ];
+    out := [];
+    for fac in EndoDescRR do
+        m, code := Explode(fac);
+        if m eq 1 then
+            Append(~out, descs[code]);
+        else
+            Append(~out, "M_" cat Sprint(m) cat " (" cat descs[code] cat ")");
+        end if;
+    end for;
+    return out;
+end function;
 
 
 intrinsic SatoTateGroup(EndoStructBase::List, GeoEndoRep::SeqEnum, GalK::List : Shorthand := "") -> MonStgElt
@@ -103,7 +118,7 @@ if Shorthand eq "" then
     GeoEndoStructBase := EndomorphismData(GeoEndoRep, GalL);
     Shorthand := SatoTateShorthandG2(GeoEndoStructBase);
 end if;
-descRR := EndoStructBase[3][3];
+descRR := DescRRShorthand(EndoStructBase[3][1]);
 K := FixedFieldExtra(L, [ Gphi(gen) : gen in gensH ]);
 
 /* Usually the shorthand and endomorphism structure of the base field determine
@@ -179,7 +194,7 @@ elif Shorthand eq "F" then
             gensH_prime := Generators(H_prime);
             GalK_prime := [* gensH_prime, Gphi *];
             EndoStruct_prime := EndomorphismData(GeoEndoRep, GalK_prime);
-            descRR_prime := EndoStruct_prime[3][3];
+            descRR_prime := DescRRShorthand(EndoStruct_prime[3][1]);
             if descRR_prime eq ["M_2 (RR)"] then
                 return "D_{6,1}";
             elif descRR_prime eq ["HH"] then
@@ -221,7 +236,7 @@ elif Shorthand eq "F" then
             gensH_prime := Generators(H_prime);
             GalK_prime := [* gensH_prime, Gphi *];
             EndoStruct_prime := EndomorphismData(GeoEndoRep, GalK_prime);
-            descRR_prime := EndoStruct_prime[3][3];
+            descRR_prime := DescRRShorthand(EndoStruct_prime[3][1]);
             if descRR_prime eq ["M_2 (RR)"] then
                 return "C_{6,1}";
             elif descRR_prime eq ["HH"] then
@@ -303,7 +318,7 @@ function SatoTateShorthandG2(GeoEndoStructBase)
 // Sato-Tate group corresponding to GeoEndoStructBase. Assumes that the genus
 // equals 2.
 
-descRR := GeoEndoStructBase[3][3];
+descRR := DescRRShorthand(GeoEndoStructBase[3][1]);
 case descRR:
     when ["RR"]:       return "A";
     when ["RR", "RR"]: return "B";


### PR DESCRIPTION

## Summary

`SatoTateGroupG2QQ` and `SatoTateShorthandG2` in `SatoTate.m` crash for any
genus-2 curve whose Sato-Tate group requires the general classification.
 Root cause is two compounding bugs, both in how `descRR`
is obtained:

1. **Wrong tuple index.** `EndomorphismStructure` (`Structure.m`) returns
   `EndoDesc` as the tuple `<EndoDescRR, EndoDescQQ, EndoDescZZ>`.
   `EndomorphismData` wraps this as `EndoData := [* EndoRep, EndoAlg, EndoDesc *]`, so
   `EndoData[3]` is `EndoDesc`, and `EndoData[3][1]` is the RR
   description. All four sites in `SatoTate.m` that extract `descRR`
   instead read `[3][3]`.

2. **Missing string conversion.** `EndomorphismAlgebraRR`'s actual return value is a `SeqEnum` of
   `<multiplicity, code>` tuples (`code` 1..4 = RR/CC/undef/HH), not the
   pre-stringified `["RR"]`/`["M_2 (RR)"]`-style sequences. The only place that
   tuple-to-string conversion existed was `Buttons.m`'s `HumanizeAlt`.

These produce:
`Runtime error: Bad argument types (Tup vs SeqEnum[MonStgElt])`, or `Runtime error: Incompatible sequences`

## Minimal reproduction

```magma
AttachSpec("<path>/endomorphisms/endomorphisms/magma/spec");
AttachSpec("<path>/MagmaPolred/spec");

P<x> := PolynomialRing(Rationals());
f := x^6 + x + 1;
C := HyperellipticCurve(f);

X := CurveExtra(C);
GeoEndoRep := GeometricEndomorphismRepresentation(X);

Q := Rationals();
L := BaseRing(GeoEndoRep[1][1]);
h := hom< Q -> L | >;

EndoDataST := EndomorphismDataWithSatoTate(GeoEndoRep, Q, h);
print "Sato-Tate group:", EndoDataST[3][5];
quit;
```

This produces 

```
$ magma -b mwe.m < /dev/null
...
In file ".../endomorphisms/magma/heuristic/SatoTate.m", line 308, column 5:
>>     when ["RR"]:       return "A";
       ^
Runtime error: Bad argument types
Argument types given: Tup, SeqEnum[MonStgElt]
```

## Fix

Read `[3][1]` instead of `[3][3]` at all four sites, and add a small
`DescRRShorthand` helper that replicates `HumanizeAlt`'s conversion:

```magma
function DescRRShorthand(EndoDescRR)
    descs := [ "RR", "CC", "undef", "HH" ];
    out := [];
    for fac in EndoDescRR do
        m, code := Explode(fac);
        if m eq 1 then
            Append(~out, descs[code]);
        else
            Append(~out, "M_" cat Sprint(m) cat " (" cat descs[code] cat ")");
        end if;
    end for;
    return out;
end function;
```

with each of the four `descRR[_prime] := EndoStructBase[3][3];` lines changed to `DescRRShorthand(...[3][1])`.

Patch below applies cleanly to current `master` (`691d1c1`) with `git am`:

```diff
From 416e73e246efdd737454345d9855f8f74e52f9a8 Mon Sep 17 00:00:00 2001
From: Hugo Nartz <hugo.nartz@loria.fr>
Date: Thu, 23 Jul 2026 15:05:59 +0200
Subject: [PATCH] fix: SatoTateGroupG2QQ/SatoTateShorthandG2 read the wrong
 EndoDesc index

EndomorphismStructure (Structure.m) returns EndoDesc as the tuple
<RR_desc, algebra_desc, ring_desc>. Index [2] is the algebra description,
so index [3] on the containing EndoStructBase/EndoStruct_prime (= [* EndoRep,
EndoAlg, EndoDesc*]) gives EndoDesc itself, and [3][1] gives the RR descriptor. 
All four call sites in SatoTate.m instead read [3][3], then compared it directly 
against string literals like ["RR"]/["M_2 (RR)"]. But the RR descriptor itself 
is a SeqEnum of <multiplicity, code> tuples (code 1..4 = RR/CC/undef/HH), 
not pre-stringified text;

Fix: read [3][1] instead of [3][3] at all four sites, and add
DescRRShorthand so the case-statement comparisons operate on
the string format they were written for.

---
 endomorphisms/magma/heuristic/SatoTate.m | 34 +++++++++++++++++++++---
 1 file changed, 30 insertions(+), 4 deletions(-)

diff --git a/endomorphisms/magma/heuristic/SatoTate.m b/endomorphisms/magma/heuristic/SatoTate.m
index cd8114e..d337e22 100644
--- a/endomorphisms/magma/heuristic/SatoTate.m
+++ b/endomorphisms/magma/heuristic/SatoTate.m
@@ -13,6 +13,32 @@ import "OverField.m": SubgroupGeneratorsUpToConjugacy;
 forward SatoTateGroupG2QQ;
 forward SatoTateShorthand;
 forward SatoTateShorthandG2;
+forward DescRRShorthand;
+
+function DescRRShorthand(EndoDescRR)
+    descs := [ "RR", "CC", "undef", "HH" ];
+    out := [];
+    for fac in EndoDescRR do
+        m, code := Explode(fac);
+        if m eq 1 then
+            Append(~out, descs[code]);
+        else
+            Append(~out, "M_" cat Sprint(m) cat " (" cat descs[code] cat ")");
+        end if;
+    end for;
+    return out;
+end function;
 
 
 intrinsic SatoTateGroup(EndoStructBase::List, GeoEndoRep::SeqEnum, GalK::List : Shorthand := "") -> MonStgElt
@@ -103,7 +129,7 @@ if Shorthand eq "" then
     GeoEndoStructBase := EndomorphismData(GeoEndoRep, GalL);
     Shorthand := SatoTateShorthandG2(GeoEndoStructBase);
 end if;
-descRR := EndoStructBase[3][3];
+descRR := DescRRShorthand(EndoStructBase[3][1]);
 K := FixedFieldExtra(L, [ Gphi(gen) : gen in gensH ]);
 
 /* Usually the shorthand and endomorphism structure of the base field determine
@@ -179,7 +205,7 @@ elif Shorthand eq "F" then
             gensH_prime := Generators(H_prime);
             GalK_prime := [* gensH_prime, Gphi *];
             EndoStruct_prime := EndomorphismData(GeoEndoRep, GalK_prime);
-            descRR_prime := EndoStruct_prime[3][3];
+            descRR_prime := DescRRShorthand(EndoStruct_prime[3][1]);
             if descRR_prime eq ["M_2 (RR)"] then
                 return "D_{6,1}";
             elif descRR_prime eq ["HH"] then
@@ -221,7 +247,7 @@ elif Shorthand eq "F" then
             gensH_prime := Generators(H_prime);
             GalK_prime := [* gensH_prime, Gphi *];
             EndoStruct_prime := EndomorphismData(GeoEndoRep, GalK_prime);
-            descRR_prime := EndoStruct_prime[3][3];
+            descRR_prime := DescRRShorthand(EndoStruct_prime[3][1]);
             if descRR_prime eq ["M_2 (RR)"] then
                 return "C_{6,1}";
             elif descRR_prime eq ["HH"] then
@@ -303,7 +329,7 @@ function SatoTateShorthandG2(GeoEndoStructBase)
 // Sato-Tate group corresponding to GeoEndoStructBase. Assumes that the genus
 // equals 2.
 
-descRR := GeoEndoStructBase[3][3];
+descRR := DescRRShorthand(GeoEndoStructBase[3][1]);
 case descRR:
     when ["RR"]:       return "A";
     when ["RR", "RR"]: return "B";
-- 
2.55.0
```
